### PR TITLE
Initialize actual_rotation with the value of the owner

### DIFF
--- a/addons/character-controller/fps/head_movement_3d.gd
+++ b/addons/character-controller/fps/head_movement_3d.gd
@@ -13,6 +13,9 @@ class_name HeadMovement3D
 ## Actual rotation of movement
 var actual_rotation := Vector3()
 
+func _ready() -> void:
+	actual_rotation.y = get_owner().rotation.y
+
 
 ## Define mouse sensitivity
 func set_mouse_sensitivity(sensitivity):


### PR DESCRIPTION
Hello there. First, I recently found this plugin and I am using it a lot, thanks!

One issue I have stumbled upon is that if you place a player with a custom initial rotation, the moment you move your mouse the view will "jump" to a different location.

I think this is because in the `head_movement.gd` script we initialize `actual_rotation` at 0 for all axis. The `Y` value will later be modified and used to set the rotation of the owner, but the owner didn't start at 0 because we set a custom rotation, that creates a desynchronization that provokes that "jump".

Demonstration of the issue: 
[Screencast from 2023-05-18 17-59-13.webm](https://github.com/expressobits/character-controller/assets/6479554/6350ff69-5880-4771-87a4-5f2676b1417c)

I've fixed it by initializing the `y` value with the rotation of the owner, that way we won't desynchronize the first time we move the mouse.

WDYT?
