### PR TITLE
Fix crouching going inactive even when head is colliding

### DIFF
--- a/core/character_controller_3d.gd
+++ b/core/character_controller_3d.gd
@@ -219,7 +219,7 @@ func move(_delta: float, input_axis := Vector2.ZERO, input_jump := false, input_
 	swim_ability.set_active(!fly_ability.is_actived())
 	jump_ability.set_active(input_jump and is_on_floor() and not head_check.is_colliding())
 	walk_ability.set_active(not is_fly_mode() and not swim_ability.is_floating())
-	crouch_ability.set_active(input_crouch and is_on_floor() and not is_floating() and not is_submerged() and not is_fly_mode())
+	crouch_ability.set_active(input_crouch and is_on_floor() and not is_floating() and not is_submerged() and not is_fly_mode() or (crouch_ability.is_actived() and crouch_ability.head_check.is_colliding()))
 	sprint_ability.set_active(input_sprint and is_on_floor() and  input_axis.y >= 0.5 and !is_crouching() and not is_fly_mode() and not swim_ability.is_floating() and not swim_ability.is_submerged())
 	
 	var multiplier = 1.0


### PR DESCRIPTION
On the test level, if you crouch under the tunnel behind the stone ramp and let go of the crouch input, your speed goes back to normal and you can even sprint.

This is because the crouch ability keeps the head low, but the controller sets the crouch active ability without considering head collision.

I have added a condition to the crouch.set_active() call in the character_controller_3d.gd file that keeps the crouch ability active if the head is still crouching down.